### PR TITLE
style: Hide placeholder text in form input

### DIFF
--- a/styles/faq.css
+++ b/styles/faq.css
@@ -163,6 +163,10 @@ padding: 0.2rem;
     border: 1px solid red;
 }
 
+.membership form input::placeholder{
+    opacity: 0;
+}
+
 .membership form button{
 
     outline: none;

--- a/styles/herosection.css
+++ b/styles/herosection.css
@@ -54,6 +54,12 @@ color: white;
     
 }
 
+#hero-section form input::placeholder{
+
+    opacity: 0;
+
+}
+
 #hero-section form input:focus ~ #placeholder,
 #hero-section form input:valid ~ #placeholder{
 


### PR DESCRIPTION
Update the CSS styles to hide the placeholder text in the form input. This change aligns with the design requirements to remove the placeholder while maintaining proper input functionality.